### PR TITLE
Can now fill triangles, and more...

### DIFF
--- a/neon2d/n2d/Program.cs
+++ b/neon2d/n2d/Program.cs
@@ -54,19 +54,8 @@ namespace n2d
                 particles.addParticle(particleProp);
             }
 
-            Colour magneta = new Colour(0, 255, 255, 255);
-
-            Colour transparentWhite = new Colour(0x00FFFFFF);
-
-            Colour argbTest = new Colour(255, 255, 255, 255);
-
-            Console.WriteLine(magneta);
-
-            Brush brush = magneta.toSysBrush();
-
-            Color systemDrawingColor = magneta.toSysColor();
-
-            Colour neonColourTest = systemDrawingColor.toNeonColour();
+            Colour test = new Colour("FF00FF00");
+            Console.WriteLine(test);
         }
 
         public override void onUpdate()

--- a/neon2d/n2d/Program.cs
+++ b/neon2d/n2d/Program.cs
@@ -90,8 +90,8 @@ namespace n2d
                 //Console.WriteLine("intersecting!");
             }
 
-            Shape.Triangle tri = new Shape.Triangle(50, 50);
-            Shape.Rectangle rect = new Shape.Rectangle(45, 80, true); //all shapes except triangle can be filled
+            Shape.Triangle tri = new Shape.Triangle(50, 50, false);
+            Shape.Rectangle rect = new Shape.Rectangle(45, 80, true);
             Shape.Ellipse ell = new Shape.Ellipse(30, 50);
             Shape.Line li = new Shape.Line(600, 400, 650, 350);
 

--- a/neon2d/neon2d/Colour.cs
+++ b/neon2d/neon2d/Colour.cs
@@ -10,49 +10,38 @@ namespace neon2d
         /// <summary>
         /// Red colour. A = 255, R = 255, G = 0, B = 0
         /// </summary>
-        public static readonly Colour RED = new Colour(0xFFFF0000);
+        public static readonly Colour RED = new Colour(255, 255, 0, 0);
 
         /// <summary>
         /// Green colour. A = 255, R = 0, G = 255, B = 0
         /// </summary>
-        public static readonly Colour GREEN = new Colour(0xFF00FF00);
+        public static readonly Colour GREEN = new Colour(255, 0, 255, 0);
 
         /// <summary>
         /// Blue Colour. A = 255, R = 0, G = 0, B = 255
         /// </summary>
-        public static readonly Colour BLUE = new Colour(0xFF0000FF);
+        public static readonly Colour BLUE = new Colour(255, 0, 0, 255);
 
         /// <summary>
         /// White colour. A = 255, R = 255, G = 255, B = 255
         /// </summary>
-        public static readonly Colour WHITE = new Colour(0xFFFFFFFF);
+        public static readonly Colour WHITE = new Colour(255, 255, 255, 255);
 
         /// <summary>
         /// Black colour. A = 255, R = 0, G = 0, B = 0
         /// </summary>
-        public static readonly Colour BLACK = new Colour(0xFF000000);
+        public static readonly Colour BLACK = new Colour(255, 0, 0, 0);
 
         /// <summary>
-        /// Black colour. A = 255, R = 255, G = 216, B = 0
+        /// Yellow colour. A = 255, R = 255, G = 216, B = 0
         /// </summary>
-        public static readonly Colour YELLOW = new Colour(0xFFFD800);
+        public static readonly Colour YELLOW = new Colour(255, 255, 216, 0);
 
-        private long _a;
         /// <summary>
         /// The alpha component of this colour.
         /// Integer (32 Bit). Should be between 0 and 255
         /// </summary>
-        public int a
-        {
-            get
-            {
-                return (int)_a;
-            }
-            set
-            {
-                _a = value;
-            }
-        }
+        public int a;
 
 
         /// <summary>
@@ -82,66 +71,37 @@ namespace neon2d
         /// <param name="b">Blue Compnent. Integer (32 bit). Between 0 and 225.</param>
         public Colour(int a, int r, int g, int b)
         {
-            this._a = a;
+            this.a = a;
             this.r = r;
             this.r = g;
             this.r = b;
         }
 
-        /// <summary>
-        /// Takes in a hexidecimal colour and assigns the A, R, G and B components
-        /// based of the colour.
-        /// </summary>
-        /// <param name="argb">Hexidecimal colour. Should be in the form 0xAARRGGBB</param>
-        public Colour(uint argb)
+        public Colour(string argb)
         {
-            this._a = (argb & 0xFF000000) >> 24;
-            this.r = (int)(argb & 0x00FF0000) >> 16;
-            this.g = (int)(argb & 0x0000FF00) >> 8;
-            this.b = (int)(argb & 0x000000FF);
-        }
+            if(!argb.StartsWith("#"))
+            {
+                neon2d.Message.neonError("Hex colour value should start with #.");
+                return;
+            }
 
-        /// <summary>
-        /// Takes in a hexidecimal colour in the format 0xRRGGBB and sets the A, R, G and B components. 
-        /// Alpha is assumed to be full (255).
-        /// </summary>
-        /// <param name="rgb">Hexidecimal colour in the format 0xFFGGBB</param>
-        public Colour(int rgb)
-        {
-            this._a = 255;
-            this.r = (int)(rgb & 0xFF0000) >> 16;
-            this.g = (int)(rgb & 0x00FF00) >> 8;
-            this.b = (int)(rgb & 0x0000FF);
-        }
+            System.Windows.Media.Color sysCol = (System.Windows.Media.Color)System.Windows.Media.ColorConverter.ConvertFromString(argb);
 
-        /// <summary>
-        /// Converts the R, G, B components into a 32 bit integer;
-        /// </summary>
-        /// <returns>int (32 bit)</returns>
-        public int getRGB()
-        {
-            return ((this.r & 0xFF) << 16) + ((this.g & 0xFF) << 8) + (this.b & 0xFF);
-        }
-
-        /// <summary>
-        /// Converts the A, R, G, B components into a 32 bit integer. [BROKEN]
-        /// </summary>
-        /// <returns>int (32 bit)</returns>
-        public int getARGB()
-        {
-            return +((this.r & 0xFF) << 16) + ((this.g & 0xFF) << 8) + (this.b & 0xFF);
+            this.a = sysCol.A;
+            this.r = sysCol.R;
+            this.g = sysCol.G;
+            this.b = sysCol.B;
         }
 
         /// <summary>
         /// Returns a string representation of this colour
-        /// In the format: "Alpha: [A] Red: [R] Green [G] Blue [B] [Newline] Hexidecimal: #AARRGGBB"
+        /// In the format: "Alpha: [A] Red: [R] Green [G] Blue [B] [Newline]"
         /// </summary>
         /// <returns></returns>
         public override string ToString()
         {
-            string rgb = "Alpha: " + (int)this._a + " Red: " + this.r + " Green: " + this.g + " Blue: " + this.b;
-            string hex = "Hexidecimal: (RGB) #" + string.Format("{0:X}", getRGB()) + "\nHexidecimal: (ARGB) #" + string.Format("{0:X}", getARGB());
-            return rgb + "\n" + hex;
+            string rgb = "Alpha: " + (int)this.a + " Red: " + this.r + " Green: " + this.g + " Blue: " + this.b;
+            return rgb + "\n";
         }
 
         public Color toSysColor()

--- a/neon2d/neon2d/Game.cs
+++ b/neon2d/neon2d/Game.cs
@@ -128,10 +128,19 @@ namespace neon2d
                 {
                     //its a triangle
                     Scene.TriStruct placeholder = (Scene.TriStruct)scene.renderlist[i];
-
-                    g.DrawLine(placeholder.p, new Point(placeholder.x, placeholder.y + placeholder.tri.triHeight), new Point(placeholder.x + (int)(placeholder.tri.triWidth / 2), placeholder.y));
-                    g.DrawLine(placeholder.p, new Point(placeholder.x + (int)(placeholder.tri.triWidth / 2), placeholder.y), new Point(placeholder.x + placeholder.tri.triWidth, placeholder.y + placeholder.tri.triHeight));
-                    g.DrawLine(placeholder.p, new Point(placeholder.x, placeholder.y + placeholder.tri.triHeight), new Point(placeholder.x + placeholder.tri.triWidth, placeholder.y + placeholder.tri.triHeight));
+                    Point [] points = {
+                         new Point(placeholder.x + (int)(placeholder.tri.triWidth / 2), placeholder.y),
+                         new Point(placeholder.x + placeholder.tri.triWidth, placeholder.y + placeholder.tri.triHeight),
+                         new Point(placeholder.x, placeholder.y + placeholder.tri.triHeight)
+                    };
+                    if(!placeholder.tri.filled)
+                    {
+                        g.DrawPolygon(placeholder.p, points);
+                    }
+                    else
+                    {
+                        g.FillPolygon(placeholder.p.Brush, points);
+                    }
                 }
                 else if (scene.renderlist[i].GetType() == typeof(Scene.ParticleRenderStruct))
                 {

--- a/neon2d/neon2d/Scene.cs
+++ b/neon2d/neon2d/Scene.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using System.Windows.Input;
 using System.Media;
+
 using System.Drawing;
 
 using neon2d.UI;

--- a/neon2d/neon2d/Shape.cs
+++ b/neon2d/neon2d/Shape.cs
@@ -58,8 +58,8 @@ namespace neon2d
             /// <param name="filled">Determines if the Rectangle is filled-in or not</param>
             public Rectangle(Math.Vector2i dimensions, bool filled = false)
             {
-                rectWidth = (int)dimensions.x;
-                rectHeight = (int)dimensions.y;
+                rectWidth = dimensions.x;
+                rectHeight = dimensions.y;
                 this.filled = filled;
             }
         
@@ -88,8 +88,8 @@ namespace neon2d
             /// <param name="filled">Determines if the Ellipse is filled-in or not</param>
             public Ellipse(Math.Vector2i dimensions, bool filled = false)
             {
-                ellipsWidth = (int)dimensions.x;
-                ellipsHeight = (int)dimensions.y;
+                ellipsWidth = dimensions.x;
+                ellipsHeight = dimensions.y;
                 this.filled = filled;
             }
 
@@ -103,20 +103,22 @@ namespace neon2d
             
             public int triWidth = 0;
             public int triHeight = 0;
+            public bool filled;
 
             /// <param name="width">The width of the Triangle's base</param>
             /// <param name="height">The height of the Triangle's peak</param>
-            public Triangle(int width, int height)
+            public Triangle(int width, int height, bool filled = false)
             {
                 triWidth = width;
                 triHeight = height;
+                this.filled = filled;
             }
             
             /// <param name="dimensions">A Vector2 representing the width of the Triangle's base and the height of the Triangle's peak</param>
             public Triangle(Math.Vector2i dimensions)
             {
-                triWidth = (int)dimensions.x;
-                triHeight = (int)dimensions.y;
+                triWidth = dimensions.x;
+                triHeight = dimensions.y;
             }
 
         }

--- a/neon2d/neon2d/neon2d.csproj
+++ b/neon2d/neon2d/neon2d.csproj
@@ -34,6 +34,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />


### PR DESCRIPTION
Triangles can now be filled via an optional parameter to the Shape constructor. This is done via `FillPolygon`.
Triangles now use the polygon render methods (`FillPolygon`, `DrawPolygon`) for drawing.
I removed unnecessary integer casts when initializing the dimensions of the shapes (They already used Vector2i?) 
